### PR TITLE
Update Detection_script.ps1

### DIFF
--- a/Local admin reporting/Log Analytics/Detection_script.ps1
+++ b/Local admin reporting/Log Analytics/Detection_script.ps1
@@ -101,10 +101,10 @@ foreach($Member in $Get_Local_AdminGroup_Members)
 			$Convert_User_to_SID = (New-Object System.Security.Principal.NTAccount("$Other_Local_Admin")).Translate([System.Security.Principal.SecurityIdentifier]).value			
 
 			$Local_admin_found++
-			$Get_LocalAdmin_Event = Get-EventLog Security -InstanceId 4732 -ea silentlycontinue | Where-Object {(($_.Message -like "*$Get_Local_AdminGroup_Name*") -and ($_.Message -like "*$Convert_User_to_SID*"))}
+			$Get_LocalAdmin_Event = Get-WinEvent -FilterHashtable @{LogName = "Security"; Id = 4732 } -ErrorAction SilentlyContinue | Where-Object { (($_.Message -like "*$Get_Local_AdminGroup_Name*") -and ($_.Message -like "*$Convert_User_to_SID*")) }
 			If($Get_LocalAdmin_Event -ne $null)
 				{
-					$Get_LocalAdmin_Event_Date = $Get_LocalAdmin_Event.TimeGenerated
+					$Get_LocalAdmin_Event_Date = $Get_LocalAdmin_Event.TimeCreated
 					$Get_LocalAdmin_Event_message = $Get_LocalAdmin_Event.message
 
 					$Event_Message = ((($Get_LocalAdmin_Event_message -split "`n").trim() | select-string -pattern "account")[0])


### PR DESCRIPTION
Substitute Get-EventLog with Get-WinEvent.
Get-WinEvent is a lot faster then Get-EventLog.
On my test there was 2 seconds vs 55 seconds. 
(difference in attributes name TimeGenerated -> TimeCreated)